### PR TITLE
Only let creators with published campaigns log in

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -164,7 +164,11 @@ class Auth::PatreonAuthenticator < Auth::OAuth2Authenticator
       SiteSetting.patreon_creator_refresh_token = auth_token[:info][:refresh_token]
     end
 
-    if auth_token[:extra][:raw_info][:campaign][:data].empty?
+    published_campaign = auth_token[:extra][:raw_info][:campaign][:data].any? do |campaign|
+      campaign[:attributes][:published_at].present?
+    end
+
+    unless published_campaign
       result.failed = true
       result.failed_reason = "You need to be a Creator to use this forum."
     else


### PR DESCRIPTION
# Overview

After reviewing the feature list with Mindy. She only wants Creators with published campaigns to be able to log in.

I have tested this locally, see gifs below:

## Unpublished creators not authorized
![unpublished_creators_no_login](https://user-images.githubusercontent.com/155541/67970074-9ea22180-fbc7-11e9-8327-6f6a7c8717e2.gif)

## Published creators still authorized
![published_creators_login](https://user-images.githubusercontent.com/155541/67970147-c3969480-fbc7-11e9-8e0e-8640c97f4042.gif)

## Finishes
* [#169485923](https://www.pivotaltracker.com/story/show/169485923)