### PR TITLE
Wording change

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -210,7 +210,7 @@ class Auth::PatreonAuthenticator < Auth::OAuth2Authenticator
 
     unless published_campaign
       result.failed = true
-      result.failed_reason = "You need to be a Creator to use this forum."
+      result.failed_reason = "This forum is for launched Patreon Creators only. Visit <a href='https://patreon.com/faq'>patreon.com/faq</a> if you need further help. Thanks!".html_safe
     else
       has_nsfw_campaign = auth_token[:extra][:raw_info][:campaign][:data].any? do |campaign|
         campaign[:attributes][:is_nsfw]


### PR DESCRIPTION
# Overview

Changes the wording on the message displayed when the user logging in isn't a creator.

## Screenshot

![image](https://user-images.githubusercontent.com/155541/68624475-c331af80-048b-11ea-8aaa-937cca2a1205.png)

## Finishes

[#1169689677](https://www.pivotaltracker.com/story/show/169689677)